### PR TITLE
More accurate badge counts, hide app notification bar

### DIFF
--- a/service.css
+++ b/service.css
@@ -1,3 +1,3 @@
-.notice {
+div[class^="noticeDefault-"] {
   display: none;
 }

--- a/webview.js
+++ b/webview.js
@@ -1,17 +1,38 @@
 import path from 'path';
 
-module.exports = (Franz) => {
+module.exports = Franz => {
   const getMessages = function getMessages() {
-    // get unread messages
-    const count = document.querySelectorAll('.guilds-wrapper .badge').length;
+    // get direct messages
+    let direct = 0;
+    const guildDirect = document.querySelectorAll('.guilds-wrapper .badge');
+    direct += getAlertCount(guildDirect);
+    const channelDirect = document.querySelectorAll('[class^="nameUnreadText-"]+div>div>div');
+    direct += getAlertCount(channelDirect);
+    
+    // get indirect messages
+    let indirect = document.querySelectorAll('.guilds-wrapper .unread').length;
+    indirect += document.querySelectorAll('[class^="nameUnreadText-"]').length;
 
     // set Franz badge
-    Franz.setBadge(count);
+    Franz.setBadge(direct, indirect);
   };
 
   // check for new messages every second and update Franz badge
   Franz.loop(getMessages);
 
   // Hide download message
-  Franz.injectCSS(path.join(__dirname, 'service.css'));
+  Franz.injectCSS(_path2.default.join(__dirname, 'service.css'));
+  
+  // Parse alert count from badges
+  function getAlertCount(badges) {
+    let alerts = 0;
+    for(let i = 0; i < badges.length; i++) {
+      const badge = badges[i];
+      if(badge && badge.childNodes && badge.childNodes.length > 0) {
+        const count = parseInt(badge.childNodes[0].nodeValue, 10);
+        alerts += count.isNaN ? 0 : count;
+      }
+    }
+    return alerts;
+  };
 };

--- a/webview.js
+++ b/webview.js
@@ -30,7 +30,9 @@ module.exports = Franz => {
       const badge = badges[i];
       if(badge && badge.childNodes && badge.childNodes.length > 0) {
         const count = parseInt(badge.childNodes[0].nodeValue, 10);
-        alerts += count.isNaN ? 0 : count;
+        alerts += count.isNaN ? 1 : count;
+      } else {
+        alerts++;
       }
     }
     return alerts;

--- a/webview.js
+++ b/webview.js
@@ -1,6 +1,6 @@
 import path from 'path';
 
-module.exports = Franz => {
+module.exports = (Franz) => {
   const getMessages = function getMessages() {
     // get direct messages
     let direct = 0;
@@ -21,7 +21,7 @@ module.exports = Franz => {
   Franz.loop(getMessages);
 
   // Hide download message
-  Franz.injectCSS(_path2.default.join(__dirname, 'service.css'));
+  Franz.injectCSS(path.join(__dirname, 'service.css'));
   
   // Parse alert count from badges
   function getAlertCount(badges) {

--- a/webview.js
+++ b/webview.js
@@ -1,5 +1,19 @@
 import path from 'path';
 
+const getAlertCount = function getAlertCount(badges) {
+  let alerts = 0;
+  for(let i = 0; i < badges.length; i++) {
+    const badge = badges[i];
+    if(badge && badge.childNodes && badge.childNodes.length > 0) {
+      const count = parseInt(badge.childNodes[0].nodeValue, 10);
+      alerts += count.isNaN ? 1 : count;
+    } else {
+      alerts++;
+    }
+  }
+  return alerts;
+};
+
 module.exports = (Franz) => {
   const getMessages = function getMessages() {
     // get direct messages
@@ -22,19 +36,4 @@ module.exports = (Franz) => {
 
   // Hide download message
   Franz.injectCSS(path.join(__dirname, 'service.css'));
-  
-  // Parse alert count from badges
-  function getAlertCount(badges) {
-    let alerts = 0;
-    for(let i = 0; i < badges.length; i++) {
-      const badge = badges[i];
-      if(badge && badge.childNodes && badge.childNodes.length > 0) {
-        const count = parseInt(badge.childNodes[0].nodeValue, 10);
-        alerts += count.isNaN ? 1 : count;
-      } else {
-        alerts++;
-      }
-    }
-    return alerts;
-  };
 };


### PR DESCRIPTION
Badge counts will attempt to read the actual amount of alerts from the multiple sources, for both direct and indirect. I've also updated the CSS selector for hiding the app ad bar.

Let me know if there's anything you'd like me to change.