### PR TITLE
Class change

### DIFF
--- a/service.css
+++ b/service.css
@@ -1,3 +1,7 @@
 .notice {
   display: none;
 }
+
+div[class^='noticeDefault-'] {
+  display: none;
+}


### PR DESCRIPTION
The top notice reminding you to download Discord desktop app changed class and it is no longer static, but generated on the server side. This selector finds it and disables it again, making Discord nice and cute again :).