### PR TITLE
Fix recipe not loading and notification counter

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -4,7 +4,7 @@ module.exports = (Franz) => {
   const getMessages = function getMessages() {
     // get unread messages
     const direct = document.querySelectorAll('[class^="guildsWrapper"] [class*="badge"]').length;
-    const indirect = document.querySelectorAll('[class^="guildsWrapper"] [class^="guild-"]+[class*="unread-"]').length;
+    const indirect = document.querySelectorAll('[class^="guildsWrapper"] [class^="guild-"][class*="unread-"]').length;
 
     // set Franz badge
     Franz.setBadge(direct, indirect);

--- a/webview.js
+++ b/webview.js
@@ -1,4 +1,4 @@
-import path from 'path';
+const path = require('path');
 
 module.exports = (Franz) => {
   const getMessages = function getMessages() {


### PR DESCRIPTION
Fix recipe not loading due to ES6 import

My assumption is that this was an oversight when splitting the recipes
into separate repositories and removing the transpiler in the process.

-----------------------------------------------------

Fix notification counter

The `unread-*` class is now attached to the `guild-*` element and not in
a separate element.